### PR TITLE
Add save! method to module "ActiveModelExtension"

### DIFF
--- a/lib/ohm/contrib/active_model_extension.rb
+++ b/lib/ohm/contrib/active_model_extension.rb
@@ -18,6 +18,10 @@ module Ohm
     def to_model
       ActiveModelInterface.new(self)
     end
+    
+    def save!
+      self.save
+    end
   end
 
   class ActiveModelInterface


### PR DESCRIPTION
I added a save! method to module "ActiveModelExtension" that calls the normal save method. Therefore you are now able to use FactoryGirl with Ohm.
