### PR TITLE
Split up created_at/updated_at timestamp modules

### DIFF
--- a/lib/ohm/timestamps.rb
+++ b/lib/ohm/timestamps.rb
@@ -18,16 +18,35 @@ module Ohm
   #   post.updated_at.to_i == Time.now.utc.to_i
   #   # => true
   module Timestamps
-    def self.included(model)
-      model.attribute :created_at, DataTypes::Type::Timestamp
-      model.attribute :updated_at, DataTypes::Type::Timestamp
+    module Created
+      def self.included(model)
+        model.attribute :created_at, DataTypes::Type::Timestamp
+      end
+
+      def save!
+        self.created_at = Time.now.utc.to_i if new?
+
+        super
+      end
     end
 
-    def save!
-      self.created_at = Time.now.utc.to_i if new?
-      self.updated_at = Time.now.utc.to_i
+    module Updated
+      def self.included(model)
+        model.attribute :updated_at, DataTypes::Type::Timestamp
+      end
 
-      super
+      def save!
+        self.updated_at = Time.now.utc.to_i
+
+        super
+      end
+    end
+
+    def self.included(model)
+      model.class_eval do
+        include Created
+        include Updated
+      end
     end
   end
 end


### PR DESCRIPTION
This splits up the modules for created_at and updated_at, so you can include both - `include Ohm::Timestamps` - or just one or the other - `include Ohm::Timestamps::Created` or `include Ohm::Timestamps::Updated`. 

This is useful when you have a (conceptually) read-only model and only want created_at, or don't require one or the other timestamp for whatever reason.
