### PR TITLE
Fixed bug causing slug to mutate input. Still optimized.

### DIFF
--- a/lib/ohm/slug.rb
+++ b/lib/ohm/slug.rb
@@ -11,12 +11,13 @@ module Ohm
     end
 
     def slug(str = to_s)
-      ret = transcode(str)
+      ret = transcode(str.dup)
       ret.gsub!("'", "")
       ret.gsub!(/[^0-9A-Za-z]/u, " ")
       ret.strip!
       ret.gsub!(/\s+/, "-")
-      ret.downcase
+      ret.downcase!
+      return ret
     end
     module_function :slug
 


### PR DESCRIPTION
So I don't have to call #dup anymore like below:

```
page = Page.new(
  name: name,
  shop: shop,
  content: content,
  slug: Ohm::Slug.slug(name.dup)
)
```
