### PR TITLE
Fix typo for Ohm::DataType

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@ moderators), then you need to put some kind of versioning in place.</p>
 
 <ol>
 <li>
-<code>Ohm::Typecast</code> has been removed in favor of <code>Ohm::DatTypes</code>.</li>
+<code>Ohm::Typecast</code> has been removed in favor of <code>Ohm::DataTypes</code>.</li>
 <li>
 <code>Ohm::Timestamping</code> has been renamed to <code>Ohm::Timestamps</code>.</li>
 <li>


### PR DESCRIPTION
Just fix a small typo I came across while reading the documentation.
