### PR TITLE
Add Dirty module for Ohm::Model

### DIFF
--- a/lib/ohm/dirty.rb
+++ b/lib/ohm/dirty.rb
@@ -1,0 +1,42 @@
+module Ohm
+  # The following is an example usage of this plugin (the methods are defined base on ActiveModel:Dirty):
+  #
+  #   class Post < Ohm::Model
+  #     include Ohm::Callbacks
+  #   end
+  #
+  #   post = Post[1]
+  #   post.changed
+  #   post.changed?
+  #   post.changes
+  #   post.changed_attributes
+  module Dirty
+    def changed
+      changes.keys
+    end
+
+    def changed?
+      changed.length > 0
+    end
+
+    def changes
+      hash = {}
+      attributes.each do |key, value|
+        if value != self.get(key)
+          hash[key] = [self.get(key), value]
+        end
+      end
+      hash
+    end
+
+    def changed_attributes
+      hash = {}
+      attributes.each do |key, value|
+        if value != self.get(key)
+          hash[key] = self.get(key)
+        end
+      end
+      hash
+    end
+  end
+end

--- a/lib/ohm/dirty.rb
+++ b/lib/ohm/dirty.rb
@@ -19,11 +19,15 @@ module Ohm
       changed.length > 0
     end
 
+    def get_original_value(att)
+      self.send(:redis).call("HGET", self.key, att)
+    end
+
     def changes
       hash = {}
       attributes.each do |key, value|
-        if value != self.get(key)
-          hash[key] = [self.get(key), value]
+        if value != get_original_value(key)
+          hash[key] = [get_original_value(key), value]
         end
       end
       hash
@@ -32,8 +36,8 @@ module Ohm
     def changed_attributes
       hash = {}
       attributes.each do |key, value|
-        if value != self.get(key)
-          hash[key] = self.get(key)
+        if value != get_original_value(key)
+          hash[key] = get_original_value(key)
         end
       end
       hash

--- a/test/dirty.rb
+++ b/test/dirty.rb
@@ -1,0 +1,44 @@
+require_relative "helper"
+require "byebug"
+require_relative "../lib/ohm/dirty"
+
+class Post < Ohm::Model
+  include Ohm::Dirty
+
+  attribute :body
+end
+
+test "changes change" do
+  post = Post.create(body: "The Body")
+  post.body = "new value"
+
+  assert post.changes == {body: ["The Body", "new value"]}
+end
+
+test "changes no change" do
+  post = Post.create(body: "The Body")
+
+  assert post.changes == {}
+end
+
+test "changed?" do
+  post = Post.create(body: "The Body")
+  post.body = "new value"
+
+  assert post.changed? == true
+end
+
+test "changed" do
+  post = Post.create(body: "The Body")
+  post.body = "new value"
+
+  assert post.changed == [:body]
+end
+
+test "changed_attributes" do
+  post = Post.create(body: "The Body")
+  post.body = "new value"
+
+  assert post.changed_attributes == {:body => "The Body"}
+end
+


### PR DESCRIPTION
Inspired from ActiveModel Dirty, I wrote a small module for Ohm::Model, the specification for methods are the same with ActiveModel in Rails. 
