### PR TITLE
allow passing and retrieve nil value for attribute with defined type

### DIFF
--- a/lib/ohm/datatypes.rb
+++ b/lib/ohm/datatypes.rb
@@ -7,9 +7,9 @@ require "set"
 module Ohm
   module DataTypes
     module Type
-      Integer   = ->(x) { x.to_i }
-      Decimal   = ->(x) { BigDecimal(x.to_s) }
-      Float     = ->(x) { x.to_f }
+      Integer   = ->(x) { x && x.to_i }
+      Decimal   = ->(x) { x && BigDecimal(x.to_s) }
+      Float     = ->(x) { x && x.to_f }
       Symbol    = ->(x) { x && x.to_sym }
       Boolean   = ->(x) { !!x }
       Time      = ->(t) { t && (t.kind_of?(::Time) ? t : ::Time.parse(t)) }


### PR DESCRIPTION
This pull request is my suggestion to allow nil value for attribute with defined type. Currently, it's quite annoying when you don't want to set a value for an "integer" field, but then it still tries to save into redis as "0", and when we get back, we get 0, not nil. Most of the time, it's not the behavior we want, because nil and 0 is very different.