### PR TITLE
allow ohm to save timestamp up to milliseconds

### DIFF
--- a/lib/ohm/datatypes.rb
+++ b/lib/ohm/datatypes.rb
@@ -14,16 +14,10 @@ module Ohm
       Boolean   = ->(x) { !!x }
       Time      = ->(t) { t && (t.kind_of?(::Time) ? t : ::Time.parse(t)) }
       Date      = ->(d) { d && (d.kind_of?(::Date) ? d : ::Date.parse(d)) }
-      Timestamp = ->(t) { t && UnixTime.at(t.to_i) }
+      Timestamp = ->(t) { t && Time.at(t.to_f) }
       Hash      = ->(h) { h && SerializedHash[h.kind_of?(::Hash) ? h : JSON(h)] }
       Array     = ->(a) { a && SerializedArray.new(a.kind_of?(::Array) ? a : JSON(a)) }
       Set       = ->(s) { s && SerializedSet.new(s.kind_of?(::Set) ? s : JSON(s)) }
-    end
-
-    class UnixTime < Time
-      def to_s
-        to_i.to_s
-      end
     end
 
     class SerializedHash < Hash


### PR DESCRIPTION
Sometimes, we want to save timestamp up to milliseconds, like in postgres. So I don't think the rounding to integer number is necessary!